### PR TITLE
add `shuffle` test

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The stable (guaranteed) API is
   the mutating methods `rand!`, `randn!` and `randexp!`
 * `rand(rng, ::AbstractArray)` (e.g. `rand(rng, 1:9)`); the streams are the same
   on 32-bits and 64-bits architectures
+* `shuffle(rng, ::AbstractArray)` and `shuffle!(rng, ::AbstractArray)`
 
 Note that the generated streams of numbers for scalars and arrays are the same,
 i.e. `rand(rng, X, n)` is equal to `[rand(rng, X) for _=1:n]` for a given `rng`

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,3 +130,17 @@ end
         end
     end
 end
+
+@testset "`shuffle` stability" begin
+    a = 1:10
+    a_shuffled = [4, 5, 6, 1, 3, 7, 10, 2, 8, 9]
+
+    # If these tests fail due to changes in the algorithm used in `Random.shuffle`,
+    # we should vendor the old implementation here to keep it stable.
+    # See <https://github.com/JuliaRandom/StableRNGs.jl/issues/10>.
+    @test shuffle(StableRNG(10), a) == a_shuffled 
+
+    b = collect(a)
+    shuffle!(StableRNG(10), b)
+    @test b == a_shuffled
+end


### PR DESCRIPTION
Closes #10. I wonder if it's worth registering a version with this so that PkgEval will catch regressions in the test in future Julia versions?